### PR TITLE
Prepare new release: 4.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           echo 'capath = /etc/grid-security/certificates' >> /etc/glite/glite-info-update-endpoints.conf
           glite-info-update-endpoints -v -c /etc/glite/glite-info-update-endpoints.conf
 
-  # Use a matrix for CentOS stream versions
+  # Use a matrix for CentOS Stream versions
   build:
     strategy:
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run Super-Linter on new changes
         uses: docker://ghcr.io/github/super-linter:slim-v4
         env:
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MARKDOWN_CONFIG_FILE: .markdownlint.json
           # Only check new or edited files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       - name: build rpm
         run: |
           make clean rpm
-          rpmlint --file .rpmlint.ini build/RPMS/noarch/*.rpm
       - name: Upload RPMs
         uses: actions/upload-artifact@v3
         with:
@@ -49,7 +48,6 @@ jobs:
       - name: build rpm
         run: |
           make clean rpm
-          rpmlint --file .rpmlint.ini build/RPMS/noarch/*.rpm
       - name: Upload RPMs
         uses: actions/upload-artifact@v3
         with:
@@ -73,7 +71,6 @@ jobs:
       - name: build rpm
         run: |
           make clean rpm
-          rpmlint --file .rpmlint.ini build/RPMS/noarch/*.rpm
       - name: Upload RPMs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "main"
 
 jobs:
   centos7:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,8 +3,9 @@
 ## Maintainers
 
 - Andrea Manzi <andrea.manzi@egi.eu>
-- Enol Fernandez <enol.fernandez@egi.eu>
 - Baptiste Grenier <baptiste.grenier@egi.eu>
+- Enol Fernandez <enol.fernandez@egi.eu>
+- Mattias Ellert <mattias.ellert@fysast.uu.se>
 
 ## Original Authors
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,9 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Quality control using GitHub actions, update community files (#) (Baptiste Grenier)
+
+## [4.0.0]
+- Quality control using GitHub actions, update community files (#33) (Baptiste Grenier)
 - Migrate to Python 3 (#28) (Enol Fernandez)
 
 ## [3.0.2]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,4 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, they will be requested for
 # review when someone opens a pull request.
-* @EGI-Federation/admins @EGI-Federation/bdii
+* @EGI-Federation/bdii

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-NAME= $(shell grep Name: *.spec | sed 's/^[^:]*:[^a-zA-Z]*//' )
-VERSION= $(shell grep Version: *.spec | sed 's/^[^:]*:[^0-9]*//' )
-RELEASE= $(shell grep Release: *.spec |cut -d"%" -f1 |sed 's/^[^:]*:[^0-9]*//')
+NAME=$(shell grep Name: *.spec | sed 's/^[^:]*:[^a-zA-Z]*//')
+VERSION=$(shell grep Version: *.spec | sed 's/^[^:]*:[^0-9]*//')
+RELEASE=$(shell grep Release: *.spec | cut -d"%" -f1 | sed 's/^[^:]*:[^0-9]*//')
 build=$(shell pwd)/build
 DATE=$(shell date "+%a, %d %b %Y %T %z")
 dist=$(shell rpm --eval '%dist' | sed 's/%dist/.el5/')

--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,15 @@ install:
 	@mkdir -p $(prefix)/usr/bin/
 	@mkdir -p $(prefix)/var/log/glite
 	@mkdir -p $(prefix)/var/cache/glite/$(NAME)
-	@mkdir -p $(prefix)/usr/share/doc/$(NAME)
-	@mkdir -p $(prefix)/usr/share/licenses/$(NAME)
+	@mkdir -p $(prefix)/usr/share/doc/$(NAME)-$(VERSION)
+	@mkdir -p $(prefix)/usr/share/licenses/$(NAME)-$(VERSION)
 	$(python) setup.py install --root $(prefix)/
 	@install -m 0644 etc/$(NAME).conf $(prefix)/etc/glite/
 	@install -m 0755 etc/cron.hourly/$(NAME) $(prefix)/etc/cron.hourly/
-	@install -m 0644 README.md $(prefix)/usr/share/doc/$(NAME)/
-	@install -m 0644 AUTHORS.md $(prefix)/usr/share/doc/$(NAME)/
-	@install -m 0644 COPYRIGHT $(prefix)/usr/share/licenses/$(NAME)/
-	@install -m 0644 LICENSE.txt $(prefix)/usr/share/licenses/$(NAME)/
+	@install -m 0644 README.md $(prefix)/usr/share/doc/$(NAME)-$(VERSION)/
+	@install -m 0644 AUTHORS.md $(prefix)/usr/share/doc/$(NAME)-$(VERSION)/
+	@install -m 0644 COPYRIGHT $(prefix)/usr/share/licenses/$(NAME)-$(VERSION)/
+	@install -m 0644 LICENSE.txt $(prefix)/usr/share/licenses/$(NAME)-$(VERSION)/
 
 dist:
 	@mkdir -p  $(build)/$(NAME)-$(VERSION)/

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,16 @@ install:
 	@mkdir -p $(prefix)/etc/cron.hourly
 	@mkdir -p $(prefix)/usr/bin/
 	@mkdir -p $(prefix)/var/log/glite
-	@mkdir -p $(prefix)/var/cache/glite/glite-info-update-endpoints
-	@mkdir -p $(prefix)/usr/share/doc/glite-info-update-endpoints
+	@mkdir -p $(prefix)/var/cache/glite/$(NAME)
+	@mkdir -p $(prefix)/usr/share/doc/$(NAME)
+	@mkdir -p $(prefix)/usr/share/licenses/$(NAME)
 	$(python) setup.py install --root $(prefix)/
-	@install -m 0644 etc/glite-info-update-endpoints.conf $(prefix)/etc/glite/
-	@install -m 0755 etc/cron.hourly/glite-info-update-endpoints $(prefix)/etc/cron.hourly/
-	@install -m 0644 README.md $(prefix)/usr/share/doc/glite-info-update-endpoints/
-	@install -m 0644 AUTHORS.md $(prefix)/usr/share/doc/glite-info-update-endpoints/
-	@install -m 0644 COPYRIGHT $(prefix)/usr/share/doc/glite-info-update-endpoints/
-	@install -m 0644 LICENSE.txt $(prefix)/usr/share/doc/glite-info-update-endpoints/
+	@install -m 0644 etc/$(NAME).conf $(prefix)/etc/glite/
+	@install -m 0755 etc/cron.hourly/$(NAME) $(prefix)/etc/cron.hourly/
+	@install -m 0644 README.md $(prefix)/usr/share/doc/$(NAME)/
+	@install -m 0644 AUTHORS.md $(prefix)/usr/share/doc/$(NAME)/
+	@install -m 0644 COPYRIGHT $(prefix)/usr/share/licenses/$(NAME)/
+	@install -m 0644 LICENSE.txt $(prefix)/usr/share/licenses/$(NAME)/
 
 dist:
 	@mkdir -p  $(build)/$(NAME)-$(VERSION)/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RELEASE=$(shell grep Release: *.spec | cut -d"%" -f1 | sed 's/^[^:]*:[^0-9]*//')
 build=$(shell pwd)/build
 DATE=$(shell date "+%a, %d %b %Y %T %z")
 dist=$(shell rpm --eval '%dist' | sed 's/%dist/.el5/')
-python ?= python
+python ?= python3
 
 default:
 	@echo "Nothing to do"
@@ -46,7 +46,7 @@ srpm: prepare
 	rpmbuild -bs --define="dist ${dist}" --define='_topdir ${build}' $(build)/SPECS/$(NAME).spec
 
 rpm: srpm
-	rpmbuild --rebuild  --define='_topdir ${build}' --define="dist ${dist}" $(build)/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)${dist}.src.rpm
+	rpmbuild --rebuild  --define='_topdir ${build}' --define="dist ${dist}" $(build)/SRPMS/$(NAME)-$(VERSION)-$(RELEASE)$(dist).src.rpm
 
 clean:
 	rm -f *~ $(NAME)-$(VERSION).tar.gz

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ The required build dependencies are:
 
 ```shell
 # Checkout tag to be packaged
-git clone https://github.com/EGI-Foundation/glite-info-update-endpoints.git
-cd glite-info-update-endpoints
-git checkout X.X.X
+$ git clone https://github.com/EGI-Foundation/glite-info-update-endpoints.git
+$ cd glite-info-update-endpoints
+$ git checkout X.X.X
 # Building in a container
-docker run --rm -v $(pwd):/source -it quay.io/centos/centos:7
-cd /source
-yum install -y rpm-build yum-utils
-yum-builddep -y glite-info-update-endpoints.spec
-make rpm
+$ docker run --rm -v $(pwd):/source -it quay.io/centos/centos:7
+[root@8a9d60c61f42 /]# cd /source
+[root@8a9d60c61f42 /]# yum install -y rpm-build yum-utils
+[root@8a9d60c61f42 /]# yum-builddep -y glite-info-update-endpoints.spec
+[root@8a9d60c61f42 /]# make rpm
 ```
 
 The RPM will be available into the `build/RPMS` directory.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ The script uses the `/etc/glite/glite-info-update-endpoints.conf` file which by
 default is configured to use EGI's list of site BDIIs. The list of site BDIIs is
 taken from the EGI GOCDBs.
 
+## Installing from packages
+
+### On RHEL-based systems
+
+On RHEL-based systems, it's possible to install packages from [EGI UMD
+packages](https://go.egi.eu/umd). The packages are build from this repository,
+and tested to work with other components part of the Unified Middleware
+Distribution.
+
 ## Building packages
 
 A Makefile allowing to build source tarball and packages is provided.
@@ -52,10 +61,11 @@ Get the source by cloning this repository and do a `make install`.
 
 - Prepare a changelog from the last version, including contributors' names
 - Prepare a PR with
-  - Updating version and changelog in `glite-info-update-endpoints.spec`
-  - Updating authors in `AUTHORS`
+  - Updating version and changelog in
+    - [CHANGELOG](CHANGELOG)
+    - [glite-info-update-endpoints.spec](glite-info-update-endpoints.spec)
 - Once the PR has been merged tag and release a new version in GitHub
-  - Packages will be built using Travis and attached to the release page
+  - Packages will be built using GitHub Actions and attached to the release page
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The RPM will be available into the `build/RPMS` directory.
 This procedure is not recommended for production deployment, please consider
 using packages.
 
-Get the source by cloning this repo and do a `make install`.
+Get the source by cloning this repository and do a `make install`.
 
 ## Preparing a release
 

--- a/glite-info-update-endpoints.spec
+++ b/glite-info-update-endpoints.spec
@@ -41,17 +41,16 @@ rm -rf %{buildroot}
 %dir %{_sysconfdir}/glite
 %dir /var/log/glite
 %dir /var/cache/glite
-%dir %{_docdir}/%{name}
 %config(noreplace) %{_sysconfdir}/glite/glite-info-update-endpoints.conf
 %{_bindir}/%{name}
 %{_sysconfdir}/cron.hourly/%{name}
 /var/cache/glite/%{name}
 %{python3_sitelib}/glite_info_update_endpoints/
 %{python3_sitelib}/glite_info_update_endpoints-*.egg-info/
-%doc %{_docdir}/%{name}/README.md
-%doc %{_docdir}/%{name}/AUTHORS.md
-%license %{_docdir}/%{name}/COPYRIGHT
-%license %{_docdir}/%{name}/LICENSE.txt
+%doc %{_docdir}/%{name}-%{version}/README.md
+%doc %{_docdir}/%{name}-%{version}/AUTHORS.md
+%license /usr/share/licenses/%{name}-%{version}/COPYRIGHT
+%license /usr/share/licenses/%{name}-%{version}/LICENSE.txt
 
 %changelog
 * Thu Dec 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1

--- a/glite-info-update-endpoints.spec
+++ b/glite-info-update-endpoints.spec
@@ -1,5 +1,5 @@
 Name:          glite-info-update-endpoints
-Version:       3.0.3
+Version:       4.0.0
 Release:       1%{?dist}
 Summary:       Updates LDAP endpoints for EGI
 Group:         Development/Libraries
@@ -14,6 +14,7 @@ BuildRequires: python3
 BuildRequires: python3-setuptools
 BuildRequires: python3-rpm-macros
 Requires:      crontabs
+Requires:      python3
 
 %description
 Updates LDAP endpoints for EGI
@@ -53,9 +54,9 @@ rm -rf %{buildroot}
 %doc %{_docdir}/%{name}/LICENSE.txt
 
 %changelog
-* Wed Nov 11 2020 Fernandez <enol.fernandez@egi.eu> - 3.0.3-1
-- Python 3 support (Enol Fernández)
-- Support CentOS 8 (Enol Fernández)
+* Thur Nov 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1
+- Quality control using GitHub actions, update community files (#33) (Baptiste Grenier)
+- Migrate to Python 3 (#28) (Enol Fernandez)
 
 * Wed Sep 23 2020 Baptiste Grenier <baptiste.grenier@egi.eu> - 3.0.2-1
 - Fix manual_file configuration (Baptiste Grenier)

--- a/glite-info-update-endpoints.spec
+++ b/glite-info-update-endpoints.spec
@@ -54,7 +54,7 @@ rm -rf %{buildroot}
 %doc %{_docdir}/%{name}/LICENSE.txt
 
 %changelog
-* Thur Nov 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1
+* Thur Dec 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1
 - Quality control using GitHub actions, update community files (#33) (Baptiste Grenier)
 - Migrate to Python 3 (#28) (Enol Fernandez)
 

--- a/glite-info-update-endpoints.spec
+++ b/glite-info-update-endpoints.spec
@@ -50,8 +50,8 @@ rm -rf %{buildroot}
 %{python3_sitelib}/glite_info_update_endpoints-*.egg-info/
 %doc %{_docdir}/%{name}/README.md
 %doc %{_docdir}/%{name}/AUTHORS.md
-%doc %{_docdir}/%{name}/COPYRIGHT
-%doc %{_docdir}/%{name}/LICENSE.txt
+%license %{_docdir}/%{name}/COPYRIGHT
+%license %{_docdir}/%{name}/LICENSE.txt
 
 %changelog
 * Thu Dec 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1

--- a/glite-info-update-endpoints.spec
+++ b/glite-info-update-endpoints.spec
@@ -54,7 +54,7 @@ rm -rf %{buildroot}
 %doc %{_docdir}/%{name}/LICENSE.txt
 
 %changelog
-* Thur Dec 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1
+* Thu Dec 15 2022 Baptiste Grenier <baptiste.grenier@egi.eu> - 4.0.0-1
 - Quality control using GitHub actions, update community files (#33) (Baptiste Grenier)
 - Migrate to Python 3 (#28) (Enol Fernandez)
 


### PR DESCRIPTION
Prepare new release.
Drop 3.03 that never got properly tagged, and bump to 4.0.0 due to python requirement change.